### PR TITLE
49 añadir link a datos de mascota en registros

### DIFF
--- a/app/registro/templates/mascota.html
+++ b/app/registro/templates/mascota.html
@@ -3,196 +3,201 @@
 {% load static %}
 
 {% block title %}
-  Ficha de Mascota
+	Ficha de Mascota
 {% endblock %}
 
 {% block extra_head %}
-  <link rel="stylesheet" href="{% static 'css/leaflet.css' %}" />
-  <script src="{% static 'js/leaflet.js' %}"></script>
-  <style>
-    .mascota-layout-row {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 1rem;
-      margin: 0;
-    }
-    
-    .mascota-section {
-      margin-bottom: 1rem;
-    }
-    
-    .mascota-card-img {
-      height: 600px;
-      width: 100%;
-      object-fit: cover;
-      border-radius: 0.5rem 0.5rem 0 0;
-    }
-    
-    .card {
-      height: 100%;
-    }
-    
-    #mapa {
-      width: 100%;
-      height: 600px;
-      min-height: 600px;
-      max-height: 900px;
-    }
-    
-    @media (min-width: 768px) {
-      .mascota-layout-row {
-        flex-wrap: nowrap;
-      }
-    
-      .mascota-section.col-md-3 {
-        flex: 0 0 25%;
-        max-width: 25%;
-      }
-    
-      .mascota-section.col-md-5 {
-        flex: 0 0 41.666667%;
-        max-width: 41.666667%;
-      }
-    
-      .mascota-section.col-md-4 {
-        flex: 0 0 33.333333%;
-        max-width: 33.333333%;
-      }
-    }
-    
-    @media (max-width: 767px) {
-      .mascota-layout-row {
-        flex-direction: column;
-      }
-    
-      .mascota-section {
-        width: 100%;
-      }
-    
-      #mapa {
-        height: 300px;
-        min-height: 300px;
-      }
-    }
-    
-    .card-title {
-      font-size: 1.3rem;
-      font-weight: 600;
-    }
-    .list-group-item strong {
-      min-width: 100px;
-      display: inline-block;
-    }
-  </style>
+	<link rel="stylesheet" href="{% static 'css/leaflet.css' %}" />
+	<script src="{% static 'js/leaflet.js' %}"></script>
+	<style>
+		.mascota-layout-row {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 1rem;
+			margin: 0;
+		}
+		
+		.mascota-section {
+			margin-bottom: 1rem;
+		}
+		
+		.mascota-card-img {
+			height: 600px;
+			width: 100%;
+			object-fit: cover;
+			border-radius: 0.5rem 0.5rem 0 0;
+		}
+		
+		.card {
+			height: 100%;
+		}
+		
+		#mapa {
+			width: 100%;
+			height: 600px;
+			min-height: 600px;
+			max-height: 900px;
+		}
+		
+		@media (min-width: 768px) {
+			.mascota-layout-row {
+				flex-wrap: nowrap;
+			}
+		
+			.mascota-section.col-md-3 {
+				flex: 0 0 25%;
+				max-width: 25%;
+			}
+		
+			.mascota-section.col-md-5 {
+				flex: 0 0 41.666667%;
+				max-width: 41.666667%;
+			}
+		
+			.mascota-section.col-md-4 {
+				flex: 0 0 33.333333%;
+				max-width: 33.333333%;
+			}
+		}
+		
+		@media (max-width: 767px) {
+			.mascota-layout-row {
+				flex-direction: column;
+			}
+		
+			.mascota-section {
+				width: 100%;
+			}
+		
+			#mapa {
+				height: 300px;
+				min-height: 300px;
+			}
+		}
+		
+		.card-title {
+			font-size: 1.3rem;
+			font-weight: 600;
+		}
+		.list-group-item strong {
+			min-width: 100px;
+			display: inline-block;
+		}
+	</style>
 {% endblock %}
 
 {% block content %}
-  <div class="container-fluid px-0">
-    <div class="row mascota-layout-row gx-0">
-      <!-- Foto de la mascota en Card -->
-      <div class="col-12 col-md-3 mascota-section">
-        <div class="card h-100 shadow-sm">
-          {% include 'registro/foto.html' with foto=registro.foto nombre=registro.nombre especie=registro.especie clase='mascota-card-img' %}
-          <div class="card-body">
-            <h5 class="card-title text-center">
-              {{ registro.nombre }}
-              {% if registro.vulnerable %}
-                <span class="badge bg-warning rounded-pill">Vulnerable</span>
-              {% endif %}
-            </h5>
-            <p class="card-text text-center mb-0">
-              <span class="badge bg-primary mb-2"><strong>ID:</strong> {{ registro.id }}</span><br />
-              <strong>Esterilizado en:</strong> {{ registro.inscripcion.campana.nombre }}<br />
-              <small class="text-muted">Registrada: {{ registro.fecha_registro }} por {{ registro.usuario }}</small>
-            </p>
-          </div>
-        </div>
-      </div>
+	<div class="container-fluid px-0">
+		<div class="row mascota-layout-row gx-0">
+			<!-- Foto de la mascota en Card -->
+			<div class="col-12 col-md-3 mascota-section">
+				<div class="card h-100 shadow-sm">
+					{% include 'registro/foto.html' with foto=registro.foto nombre=registro.nombre especie=registro.especie clase='mascota-card-img' %}
+					<div class="card-body">
+						<h5 class="card-title text-center">
+							{{ registro.nombre }}
+							{% if registro.vulnerable %}
+								<span class="badge bg-warning rounded-pill">Vulnerable</span>
+							{% endif %}
+						</h5>
+						<p class="card-text text-center mb-0">
+							<span class="badge bg-primary mb-2"><strong>ID:</strong> {{ registro.id }}</span><br />
+							<strong>Esterilizado en:</strong> <a href="{{ registro.inscripcion.campana.get_absolute_url }}">{{ registro.inscripcion.campana.nombre }} | {{ registro.inscripcion.campana.barrio }}-{{ registro.inscripcion.campana.parroquia }}</a><br />
+							<small class="text-muted">Registrada: {{ registro.fecha_registro }} por {{ registro.usuario }}</small>
+						</p>
+					</div>
+				</div>
+			</div>
 
-      <!-- Información de la mascota -->
-      <div class="col-12 col-md-5 mascota-section">
-        <div class="card h-100 shadow-sm">
-          <div class="card-body">
-            <h5 class="card-title mb-3">Información de la Mascota</h5>
-            <ul class="list-group list-group-flush">
-              <li class="list-group-item d-flex justify-content-between align-items-center">
-                <strong>Cantón:</strong> <span>{{ registro.get_canton_tutor_display }}</span>
-              </li>
-              <li class="list-group-item d-flex justify-content-between align-items-center">
-                <strong>Parroquia:</strong> <span>{{ registro.get_parroquia_tutor_display }}</span>
-              </li>
-              <li class="list-group-item d-flex justify-content-between align-items-center">
-                <strong>Barrio:</strong> <span>{{ registro.barrio_tutor }}</span>
-              </li>
-              <li class="list-group-item d-flex justify-content-between align-items-center">
-                <strong>Nº Turno:</strong> <span>{{ registro.numero_turno }}</span>
-              </li>
-              <li class="list-group-item d-flex justify-content-between align-items-center">
-                <strong>Especie:</strong> <span>{{ registro.get_especie_display }}</span>
-              </li>
-              <li class="list-group-item d-flex justify-content-between align-items-center">
-                <strong>Género:</strong> <span>{{ registro.get_sexo_display }}</span>
-              </li>
-              <li class="list-group-item d-flex justify-content-between align-items-center">
-                <strong>Edad al esterilizar:</strong>
-                <span>{% include 'registro/edad.html' with edad_anos=registro.edad_anos edad_meses=registro.edad_meses completo=True %}</span>
-              </li>
-              {% if registro.color_principal %}
-                <li class="list-group-item d-flex justify-content-between align-items-center">
-                  <strong>Color:</strong>
-                  <span>
-                    {{ registro.get_color_principal_display }}
-                    {% if registro.color_secundario %}
-                      | {{ registro.get_color_secundario_display }}
-                    {% endif %}
-                  </span>
-                </li>
-              {% endif %}
-              <li class="list-group-item d-flex justify-content-between align-items-center">
-                <strong>Raza:</strong> <span>{{ registro.raza_mascota }}</span>
-              </li>
-              {% if registro.n_animales_hogar > 0 %}
-                <li class="list-group-item d-flex justify-content-between align-items-center">
-                  <strong>Comparte hogar con:</strong>
-                  <span>
-                    {{ registro.n_animales_hogar }} animal{{ registro.n_animales_hogar|pluralize:'es' }}
-                    donde {{ registro.n_animales_hogar_esterilizadas }} están esterilizado{{ registro.n_animales_hogar_esterilizadas|pluralize }}
-                  </span>
-                </li>
-              {% endif %}
-            </ul>
-          </div>
-        </div>
-      </div>
+			<!-- Información de la mascota -->
+			<div class="col-12 col-md-5 mascota-section">
+				<div class="card h-100 shadow-sm">
+					<div class="card-body">
+						<h5 class="card-title mb-3">Información de la Mascota</h5>
+						<ul class="list-group list-group-flush">
+							<li class="list-group-item d-flex justify-content-between align-items-center">
+								<strong>Cantón:</strong> <span>{{ registro.get_canton_tutor_display }}</span>
+							</li>
+							<li class="list-group-item d-flex justify-content-between align-items-center">
+								<strong>Parroquia:</strong> <span>{{ registro.get_parroquia_tutor_display }}</span>
+							</li>
+							<li class="list-group-item d-flex justify-content-between align-items-center">
+								<strong>Barrio:</strong> <span>{{ registro.barrio_tutor }}</span>
+							</li>
+							<li class="list-group-item d-flex justify-content-between align-items-center">
+								<strong>Nº Turno:</strong> <span>{{ registro.numero_turno }}</span>
+							</li>
+							<li class="list-group-item d-flex justify-content-between align-items-center">
+								<strong>Especie:</strong> <span>{{ registro.get_especie_display }}</span>
+							</li>
+							<li class="list-group-item d-flex justify-content-between align-items-center">
+								<strong>Género:</strong> <span>{{ registro.get_sexo_display }}</span>
+							</li>
+							<li class="list-group-item d-flex justify-content-between align-items-center">
+								<strong>Edad al esterilizar:</strong>
+								<span>{% include 'registro/edad.html' with edad_anos=registro.edad_anos edad_meses=registro.edad_meses completo=True %}</span>
+							</li>
+							{% if registro.color_principal %}
+								<li class="list-group-item d-flex justify-content-between align-items-center">
+									<strong>Color:</strong>
+									<span>
+										{{ registro.get_color_principal_display }}
+										{% if registro.color_secundario %}
+											| {{ registro.get_color_secundario_display }}
+										{% endif %}
+									</span>
+								</li>
+							{% endif %}
+							<li class="list-group-item d-flex justify-content-between align-items-center">
+								<strong>Raza:</strong> <span>{{ registro.raza_mascota }}</span>
+							</li>
+							{% if registro.n_animales_hogar > 0 %}
+								<li class="list-group-item d-flex justify-content-between align-items-center">
+									<strong>Comparte hogar con:</strong>
+									<span>
+										{{ registro.n_animales_hogar }} animal{{ registro.n_animales_hogar|pluralize:'es' }}
+										donde {{ registro.n_animales_hogar_esterilizadas }} están esterilizado{{ registro.n_animales_hogar_esterilizadas|pluralize }}
+									</span>
+								</li>
+							{% endif %}
+							{% if user.is_authenticated %}
+								<li class="list-group-item d-flex justify-content-between align-items-center">
+									<strong>Tutor:</strong> <span>{{ registro.nombres_tutor }}</span>
+								</li>
+								<li class="list-group-item d-flex justify-content-between align-items-center">
+									<strong>Nº Teléfono:</strong> <span>{{ registro.numero_telefono_tutor|stringformat:'010d' }}</span>
+								</li>
+								<li class="list-group-item d-flex justify-content-between align-items-center">
+									<strong>Cédula Identidad:</strong> <span>{{ registro.cedula_identidad|stringformat:'010d' }}</span>
+								</li>
+							{% endif %}
+						</ul>
+					</div>
+				</div>
+			</div>
 
-      <!-- Mapa -->
-      <div class="col-12 col-md-4 mascota-section">
-        <div class="card h-100 shadow-sm">
-          <div class="card-body">
-            <h5 class="card-title mb-3">Ubicación</h5>
-            <div id="mapa"></div>
-          </div>
-        </div>
-      </div>
-    </div>
+			<!-- Mapa -->
+			<div class="col-12 col-md-4 mascota-section">
+				<div class="card h-100 shadow-sm">
+					<div class="card-body">
+						<h5 class="card-title mb-3">Ubicación</h5>
+						<div id="mapa"></div>
+					</div>
+				</div>
+			</div>
+		</div>
 
-    <div class="row mt-4">
-      <div class="col text-center">
-        <a href="{% url 'mascotas:index' %}" class="btn btn-outline-primary"><i class="bi bi-arrow-left"></i> Volver a la lista</a>
-      </div>
-    </div>
-  </div>
+		<div class="row mt-4">
+			<div class="col text-center">
+				<a href="{% url 'mascotas:index' %}" class="btn btn-outline-primary"><i class="bi bi-arrow-left"></i> Volver a la lista</a>
+			</div>
+		</div>
+	</div>
 {% endblock %}
 
 {% block extra_js %}
-  <script src="{% static 'js/mapa.js' %}"></script>
+	<script src="{% static 'js/mapa.js' %}"></script>
 {% endblock %}
 {% block domready %}
-    {% include "icono.html" %}
-    let mapInitialized = false;
-    const locaciones = [['{{registro.canton_tutor}}', '{{registro.parroquia_tutor}}', '{{registro.barrio_tutor}}', 1]];
-    if (!mapInitialized) {
-      mapInitialized = true;
-      inicializarMapa(locaciones, "{% static 'assets/locaciones.json' %}", icono);
-    }
+	{% include 'icono.html' %}let mapInitialized = false; const locaciones = [['{{ registro.canton_tutor }}', '{{ registro.parroquia_tutor }}', '{{ registro.barrio_tutor }}', 1]]; if (!mapInitialized) { mapInitialized = true; inicializarMapa(locaciones, "{% static 'assets/locaciones.json' %}", icono); }
 {% endblock %}

--- a/app/registro/templates/registro/lista.html
+++ b/app/registro/templates/registro/lista.html
@@ -3,93 +3,98 @@
 {% load static %}
 {% load django_bootstrap5 %}
 {% block title %}
-  Ver todos los registrados
+	Ver todos los registrados
 {% endblock %}
 {% block breadcrumb %}
-  {% include 'campana/breadcrumb.html' %}
+	{% include 'campana/breadcrumb.html' %}
 {% endblock %}
 
 {% block content %}
-  <div class="container my-2">
-    <h3 class="text-center mb-2">Todos los registros</h3>
-    <h4 class="text-center text-muted mb-4">{{ campana.nombre }}</h4>
-    <div class="text-center mb-4">
-      {% url 'inscripcion:index' campana.id as url_mascota %}
-      {% bootstrap_button '<i class="bi bi-plus-circle"></i> Registrar Mascota' button_type='link' href=url_mascota size='lg' %}
-    </div>
+	<div class="container my-2">
+		<h3 class="text-center mb-2">Todos los registros</h3>
+		<h4 class="text-center text-muted mb-4">{{ campana.nombre }}</h4>
+		<div class="text-center mb-4">
+			{% url 'inscripcion:index' campana.id as url_mascota %}
+			{% bootstrap_button '<i class="bi bi-plus-circle"></i> Registrar Mascota' button_type='link' href=url_mascota size='lg' %}
+		</div>
 
-    <div class="card shadow-sm mb-5">
-      <div class="card-body">
-        <h5 class="card-title mb-3">Buscar participantes</h5>
-        <form class="row g-2" method="get" action="{% url 'registro:lista' campana.id %}">
-          <div class="col-md-6">
-            <input type="text" name="query" placeholder="Buscar por tutor" class="form-control" />
-          </div>
-          <div class="col-auto">
-            {% bootstrap_button '<i class="bi bi-search"></i> Buscar' %}
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-  <div class="card shadow-sm">
-    <div class="card-body">
-      {% if registros %}
-        <h5 class="card-title mb-4"><i class="bi bi-list"></i> Mascotas inscritas</h5>
-        {% if registros.has_other_pages %}
-          {% bootstrap_pagination registros %}
-        {% endif %}
-        <div class="table-responsive-sm">
-          <table class="table table-striped table-hover align-middle">
-            <thead class="table-success">
-              <tr>
-                <th>ID</th>
-                <th>Número Turno</th>
-                <th>Foto</th>
-                <th>Nombre Mascota</th>
-                <th>Nombre Tutor</th>
-                <th>Especie</th>
-                <th>Género</th>
-                {% if request.user.is_authenticated %}
-                  <th>Ver Ficha</th>
-                  <th>Imprimir ficha</th>
-                {% endif %}
-              </tr>
-            </thead>
-            <tbody>
-              {% for registro in registros %}
-                <tr>
-                  <td>{{ registro.id }}</td>
-                  <td>
-                    <span class="badge bg-primary">{{ registro.numero_turno }}</span>
-                  </td>
-                  <td>
-                    {% include 'registro/foto.html' with foto=registro.foto nombre=registro.nombre especie=registro.especie clase='imagen-mascotas' thumbnail=True %}
-                  </td>
-                  <td>{{ registro.nombre }}</td>
-                  <td>{{ registro.nombres_tutor }}</td>
-                  <td>{{ registro.especie }} {{ registro.get_especie_display }}</td>
-                  <td>
-                    {% include 'registro/genero.html' with sexo=registro.sexo get_sexo_display=registro.get_sexo_display %}
-                  </td>
-                  {% if request.user.is_authenticated %}
-                    <td>
-                      {% url 'registro:ver_ficha' registro.inscripcion.campana.id registro.id as url_ficha %}
-                      {% bootstrap_button '<i class="bi bi-eye"></i> Ver Ficha' button_type='link' href=url_ficha size='sm' button_class='btn-success' %}
-                    </td>
-                    <td>
-                      {% url 'registro:generar_pdf' registro.id as url_imprimir %}
-                      {% bootstrap_button '<i class="bi bi-printer"></i> Imprimir ficha' button_type='link' href=url_imprimir size='sm' %}
-                    </td>
-                  {% endif %}
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      {% else %}
-        <h3>No hay mascotas registradas, por favor registre una</h3>
-      {% endif %}
-    </div>
-  </div>
+		<div class="card shadow-sm mb-5">
+			<div class="card-body">
+				<h5 class="card-title mb-3">Buscar participantes</h5>
+				<form class="row g-2" method="get" action="{% url 'registro:lista' campana.id %}">
+					<div class="col-md-6">
+						<input type="text" name="query" placeholder="Buscar por tutor" class="form-control" />
+					</div>
+					<div class="col-auto">
+						{% bootstrap_button '<i class="bi bi-search"></i> Buscar' %}
+					</div>
+				</form>
+			</div>
+		</div>
+	</div>
+	<div class="card shadow-sm">
+		<div class="card-body">
+			{% if registros %}
+				<h5 class="card-title mb-4"><i class="bi bi-list"></i> Mascotas inscritas</h5>
+				{% if registros.has_other_pages %}
+					{% bootstrap_pagination registros %}
+				{% endif %}
+				<div class="table-responsive-sm">
+					<table class="table table-striped table-hover align-middle">
+						<thead class="table-success">
+							<tr>
+								<th>ID</th>
+								<th>Número Turno</th>
+								<th>Nombre Mascota</th>
+								<th>Foto</th>
+								<th>Nombre Tutor</th>
+								<th>Especie</th>
+								<th>Género</th>
+								{% if request.user.is_authenticated %}
+									<th>Ver Ficha</th>
+									<th>Imprimir ficha</th>
+								{% endif %}
+							</tr>
+						</thead>
+						<tbody>
+							{% for registro in registros %}
+								<tr>
+									<td>{{ registro.id }}</td>
+									<td>
+										<span class="badge bg-primary">{{ registro.numero_turno }}</span>
+									</td>
+									<td>
+										<a href="{{ registro.get_absolute_url }}">{{ registro.nombre }}</a>
+									</td>
+									<td>
+										{% include 'registro/foto.html' with foto=registro.foto nombre=registro.nombre especie=registro.especie clase='imagen-mascotas' thumbnail=True %}
+									</td>
+									<td>{{ registro.nombres_tutor }}</td>
+									<td>{{ registro.especie }} {{ registro.get_especie_display }}</td>
+									<td>
+										{% include 'registro/genero.html' with sexo=registro.sexo get_sexo_display=registro.get_sexo_display %}
+									</td>
+									{% if request.user.is_authenticated %}
+										<td>
+											{% url 'registro:ver_ficha' registro.inscripcion.campana.id registro.id as url_ficha %}
+											{% bootstrap_button '<i class="bi bi-eye"></i> Ver Ficha' button_type='link' href=url_ficha size='sm' button_class='btn-success' %}
+										</td>
+										<td>
+											{% url 'registro:generar_pdf' registro.id as url_imprimir %}
+											{% bootstrap_button '<i class="bi bi-printer"></i> Imprimir ficha' button_type='link' href=url_imprimir size='sm' %}
+										</td>
+									{% endif %}
+								</tr>
+							{% endfor %}
+						</tbody>
+					</table>
+				</div>
+				{% if registros.has_other_pages %}
+					{% bootstrap_pagination registros %}
+				{% endif %}
+			{% else %}
+				<h3>No hay mascotas registradas, por favor registre una</h3>
+			{% endif %}
+		</div>
+	</div>
 {% endblock %}

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,4 +4,4 @@ easy-thumbnails==2.*
 mysqlclient==2.*
 pillow==12.*
 uwsgi==2.*
-weasyprint==67.*
+weasyprint==68.*


### PR DESCRIPTION
## ¿Qué hay de nuevo?
- Actualizar la versión de `weasyprint`
- En la vista de registros, añadir paginación abajo y link a la ficha de cada mascota
- En la vista de mascotas, mostrar datos de tutores y link a la campaña

Cierra #49 